### PR TITLE
Set translatesAutoresizingMaskIntoConstraints to false when view is pinned

### DIFF
--- a/Pins/UIView+Pins.swift
+++ b/Pins/UIView+Pins.swift
@@ -85,6 +85,7 @@ public extension UIView {
         let constraint = anchor(for: edge).constraint(equalTo: anchorAttachment, constant: padding)
         constraint.isActive = true
 
+        translatesAutoresizingMaskIntoConstraints = false
         return constraint
     }
 
@@ -93,6 +94,7 @@ public extension UIView {
         let constraint = anchor(for: edge).constraint(equalTo: anchorAttachment, constant: padding)
         constraint.isActive = true
 
+        translatesAutoresizingMaskIntoConstraints = false
         return constraint
     }
 
@@ -101,6 +103,7 @@ public extension UIView {
         let constraint = anchor(for: dimension).constraint(equalTo: anchorAttachment, constant: padding)
         constraint.isActive = true
 
+        translatesAutoresizingMaskIntoConstraints = false
         return constraint
     }
 
@@ -109,6 +112,7 @@ public extension UIView {
         let constraint = anchor(for: dimension).constraint(equalToConstant: size)
         constraint.isActive = true
 
+        translatesAutoresizingMaskIntoConstraints = false
         return constraint
     }
 

--- a/PinsTests/PinsTests.swift
+++ b/PinsTests/PinsTests.swift
@@ -140,7 +140,6 @@ class PinsTests: XCTestCase {
 
     private func setupViews() {
         nestedView = UIView()
-        nestedView.translatesAutoresizingMaskIntoConstraints = false
         mainView.addSubview(nestedView)
     }
 


### PR DESCRIPTION
@joshpc just threw this together to try disabling `translatesAutoresizingMaskIntoConstraints` automatically. Not sure about the implicit behaviour, but it is nice not needing to call that on every view when you most likely don't want it at this point anyways. Curious what you think.

Could also add a global setting to enable or disable this behaviour.