### PR TITLE
Use leading/trailing in bounds pin rather than left/right

### DIFF
--- a/Pins/UIView+Pins.swift
+++ b/Pins/UIView+Pins.swift
@@ -50,17 +50,17 @@ public extension UIView {
     ///   - padding: Optional padding to add between the anchors.
     /// - Returns: Array of activated `NSLayoutConstraint` objects that were created.
     @discardableResult
-    func pin(leftTo left: NSLayoutAnchor<NSLayoutXAxisAnchor>?, topTo top: NSLayoutAnchor<NSLayoutYAxisAnchor>?, rightTo right: NSLayoutAnchor<NSLayoutXAxisAnchor>?, bottomTo bottom: NSLayoutAnchor<NSLayoutYAxisAnchor>?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
+    func pin(leadingTo leading: NSLayoutAnchor<NSLayoutXAxisAnchor>?, topTo top: NSLayoutAnchor<NSLayoutYAxisAnchor>?, trailingTo trailing: NSLayoutAnchor<NSLayoutXAxisAnchor>?, bottomTo bottom: NSLayoutAnchor<NSLayoutYAxisAnchor>?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
 
-        if let left = left {
-            constraints.append(pin(.left, to: left, padding: padding))
+        if let leading = leading {
+            constraints.append(pin(.leading, to: leading, padding: padding))
         }
         if let top = top {
             constraints.append(pin(.top, to: top, padding: padding))
         }
-        if let right = right {
-            constraints.append(pin(.right, to: right, padding: padding))
+        if let trailing = trailing {
+            constraints.append(pin(.trailing, to: trailing, padding: padding))
         }
         if let bottom = bottom {
             constraints.append(pin(.bottom, to: bottom, padding: padding))
@@ -79,17 +79,17 @@ public extension UIView {
     ///   - padding: Optional padding to add between the anchors.
     /// - Returns: Array of activated `NSLayoutConstraint` objects that were created.
     @discardableResult
-    func pin(leftToView left: UIView?, topToView top: UIView?, rightToView right: UIView?, bottomToView bottom: UIView?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
+    func pin(leadingToView leading: UIView?, topToView top: UIView?, trailingToView trailing: UIView?, bottomToView bottom: UIView?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
 
-        if let left = left {
-            constraints.append(pin(.left, to: left, padding: padding))
+        if let leading = leading {
+            constraints.append(pin(.leading, to: leading, padding: padding))
         }
         if let top = top {
             constraints.append(pin(.top, to: top, padding: padding))
         }
-        if let right = right {
-            constraints.append(pin(.right, to: right, padding: padding))
+        if let trailing = trailing {
+            constraints.append(pin(.trailing, to: trailing, padding: padding))
         }
         if let bottom = bottom {
             constraints.append(pin(.bottom, to: bottom, padding: padding))
@@ -108,9 +108,9 @@ public extension UIView {
     func pin(_ view: UIView, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
 
-        constraints.append(pin(.left, to: view, padding: padding))
+        constraints.append(pin(.leading, to: view, padding: padding))
         constraints.append(pin(.top, to: view, padding: padding))
-        constraints.append(pin(.right, to: view, padding: padding))
+        constraints.append(pin(.trailing, to: view, padding: padding))
         constraints.append(pin(.bottom, to: view, padding: padding))
 
         return constraints

--- a/PinsTests/PinsTests.swift
+++ b/PinsTests/PinsTests.swift
@@ -32,7 +32,7 @@ class PinsTests: XCTestCase {
 
     func testPinToBounds() {
         evaluateConstraints() {
-            nestedView.pin(leftTo: mainView.leftAnchor, topTo: mainView.topAnchor, rightTo: mainView.rightAnchor, bottomTo: mainView.bottomAnchor)
+            nestedView.pin(leadingTo: mainView.leadingAnchor, topTo: mainView.topAnchor, trailingTo: mainView.trailingAnchor, bottomTo: mainView.bottomAnchor)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)
@@ -48,7 +48,7 @@ class PinsTests: XCTestCase {
 
     func testPinToBoundsWithPadding() {
         evaluateConstraints() {
-            nestedView.pin(leftTo: mainView.leftAnchor, topTo: mainView.topAnchor, rightTo: mainView.rightAnchor, bottomTo: mainView.bottomAnchor, padding: 10)
+            nestedView.pin(leadingTo: mainView.leadingAnchor, topTo: mainView.topAnchor, trailingTo: mainView.trailingAnchor, bottomTo: mainView.bottomAnchor, padding: 10)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)
@@ -64,7 +64,7 @@ class PinsTests: XCTestCase {
 
     func testPinToBoundsWithOptionals() {
         evaluateConstraints() {
-            nestedView.pin(leftTo: mainView.leftAnchor, topTo: nil, rightTo: mainView.rightAnchor, bottomTo: nil)
+            nestedView.pin(leadingTo: mainView.leadingAnchor, topTo: nil, trailingTo: mainView.trailingAnchor, bottomTo: nil)
         }
 
         XCTAssertEqual(mainView.constraints.count, 2)
@@ -113,7 +113,7 @@ class PinsTests: XCTestCase {
 
     func testPinBoundsToSpecificView() {
         evaluateConstraints() {
-            nestedView.pin(leftToView: mainView, topToView: mainView, rightToView: mainView, bottomToView: mainView)
+            nestedView.pin(leadingToView: mainView, topToView: mainView, trailingToView: mainView, bottomToView: mainView)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)
@@ -129,7 +129,7 @@ class PinsTests: XCTestCase {
 
     func testPinBoundsToSpecificViewWithPadding() {
         evaluateConstraints() {
-            nestedView.pin(leftToView: mainView, topToView: mainView, rightToView: mainView, bottomToView: mainView, padding: 10)
+            nestedView.pin(leadingToView: mainView, topToView: mainView, trailingToView: mainView, bottomToView: mainView, padding: 10)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)


### PR DESCRIPTION
Changed the method signature as well to reflect what you are actually pinning against.

cc @joshpc