### PR TITLE
Use generics so we don't need different symbols for pin to anchor and pin to view

### DIFF
--- a/Pins/View+Pins.swift
+++ b/Pins/View+Pins.swift
@@ -87,7 +87,7 @@ public extension PView {
     ///   - padding: Optional padding to add between the anchors.
     /// - Returns: Array of activated `NSLayoutConstraint` objects that were created.
     @discardableResult
-    func pin(leadingToView leading: PView?, topToView top: PView?, trailingToView trailing: PView?, bottomToView bottom: PView?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
+    func pin<View:PView>(leadingTo leading: View?, topTo top: View?, trailingTo trailing: View?, bottomTo bottom: View?, padding: CGFloat = 0.0) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
 
         if let leading = leading {

--- a/PinsTests/PinsTests.swift
+++ b/PinsTests/PinsTests.swift
@@ -160,7 +160,7 @@ class PinsTests: XCTestCase {
 
     func testPinBoundsToSpecificView() {
         evaluateConstraints() {
-            nestedView.pin(leadingToView: mainView, topToView: mainView, trailingToView: mainView, bottomToView: mainView)
+            nestedView.pin(leadingTo: mainView, topTo: mainView, trailingTo: mainView, bottomTo: mainView)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)
@@ -176,7 +176,7 @@ class PinsTests: XCTestCase {
 
     func testPinBoundsToSpecificViewWithPadding() {
         evaluateConstraints() {
-            nestedView.pin(leadingToView: mainView, topToView: mainView, trailingToView: mainView, bottomToView: mainView, padding: 10)
+            nestedView.pin(leadingTo: mainView, topTo: mainView, trailingTo: mainView, bottomTo: mainView, padding: 10)
         }
 
         XCTAssertEqual(mainView.constraints.count, 4)


### PR DESCRIPTION
if I use 

``` swift
pin(leadingTo leading: PView?, topTo top: PView?, trailingTo trailing: PView?, bottomTo bottom: PView?, padding: CGFloat = 0.0) -> [NSLayoutConstraint]
```

I get a method conflict with the anchor version. Using a generic gets around that it seems so we can have the same argument symbols.

@joshpc FYI